### PR TITLE
Fix camera manager build errors

### DIFF
--- a/custom/CMakeLists.txt
+++ b/custom/CMakeLists.txt
@@ -8,11 +8,14 @@ set(QGC_RESOURCES ${QGC_RESOURCES} ${CUSTOM_RESOURCES} CACHE STRING "Paths to .q
 set(CUSTOM_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/CustomPlugin.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/src/CustomPlugin.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/CameraManagerPlugin.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/CameraManagerPlugin.h
     CACHE INTERNAL "" FORCE
 )
 
 set(CUSTOM_LIBRARIES
     Qt6::Core
+    Qt6::Quick
     CACHE INTERNAL "" FORCE
 )
 

--- a/custom/cmake/CustomOverrides.cmake
+++ b/custom/cmake/CustomOverrides.cmake
@@ -2,6 +2,8 @@
 list(APPEND CUSTOM_SOURCES
     ${CMAKE_SOURCE_DIR}/custom/src/CustomPlugin.cc
     ${CMAKE_SOURCE_DIR}/custom/src/CustomPlugin.h
+    ${CMAKE_SOURCE_DIR}/custom/src/CameraManagerPlugin.cc
+    ${CMAKE_SOURCE_DIR}/custom/src/CameraManagerPlugin.h
 )
 
 # QML файл плагіна

--- a/custom/custom.qrc
+++ b/custom/custom.qrc
@@ -3,5 +3,12 @@
         <file alias="QGroundControl/AppSettings/ServoControlSettings.qml">src/ServoControlSettings.qml</file>
         <file alias="QGroundControl/AppSettings/SettingsPagesModel.qml">src/SettingsPagesModel.qml</file>
         <file alias="QGroundControl/FlightDisplay/FlyViewCustomLayer.qml">src/FlyViewCustomLayer.qml</file>
+        <file alias="QGroundControl/AppSettings/CameraManagerSettings.qml">src/CameraManagerSettings.qml</file>
+        <file alias="QGroundControl/FlightDisplay/CameraStreamView.qml">src/CameraStreamView.qml</file>
+        <file alias="QGroundControl/FlightMap/Widgets/PhotoVideoControl.qml">src/FlightMap/Widgets/PhotoVideoControl.qml</file>
+    </qresource>
+    <qresource prefix="/Custom/res">
+        <file>res/camera_toggle_off.svg</file>
+        <file>res/camera_toggle_on.svg</file>
     </qresource>
 </RCC>

--- a/custom/res/camera_toggle_off.svg
+++ b/custom/res/camera_toggle_off.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 8.25H13a0.75 0.75 0 0 1 0.75 0.75v6a0.75 0.75 0 0 1-0.75 0.75H4A0.75 0.75 0 0 1 3.25 15V9A0.75 0.75 0 0 1 4 8.25Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/>
+  <path d="M13.75 10.1L19.5 6.75V17.25L13.75 13.9Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/>
+  <circle cx="8.5" cy="11.5" r="1.75" stroke="currentColor" stroke-width="1.5" fill="none"/>
+  <path d="M4 19L19.5 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/custom/res/camera_toggle_on.svg
+++ b/custom/res/camera_toggle_on.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 8.25H13a0.75 0.75 0 0 1 0.75 0.75v6a0.75 0.75 0 0 1-0.75 0.75H4A0.75 0.75 0 0 1 3.25 15V9A0.75 0.75 0 0 1 4 8.25Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/>
+  <path d="M13.75 10.1L19.5 6.75V17.25L13.75 13.9Z" fill="currentColor" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/>
+  <circle cx="8.5" cy="11.5" r="1.75" fill="currentColor"/>
+</svg>

--- a/custom/src/CameraManagerPlugin.cc
+++ b/custom/src/CameraManagerPlugin.cc
@@ -1,0 +1,616 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "CameraManagerPlugin.h"
+
+#include "Fact.h"
+#include "QGCCorePlugin.h"
+#include "QGCLoggingCategory.h"
+#include "SettingsManager.h"
+#include "VideoReceiver.h"
+#include "VideoSettings.h"
+
+#include <algorithm>
+#include <QtCore/QJsonArray>
+#include <QtCore/QJsonDocument>
+#include <QtCore/QJsonObject>
+#include <QtCore/QPointer>
+#include <QtCore/QSettings>
+#include <QtCore/QTimer>
+#include <QtCore/QVariant>
+#include <QtCore/QVariantMap>
+#include <QtCore/QtGlobal>
+#include <QtQuick/QQuickItem>
+
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+
+QGC_LOGGING_CATEGORY(CustomCameraManagerLog, "gcs.custom.cameramanager")
+
+namespace
+{
+static constexpr const char *kSettingsGroup = "CustomCameraManager";
+static constexpr const char *kStreamsKey = "streams";
+static constexpr const char *kPrimaryKey = "primaryIndex";
+}
+
+CameraManagerPlugin::CameraManagerPlugin(QObject *parent)
+    : QObject(parent)
+    , _videoSettings(SettingsManager::instance()->videoSettings())
+{
+    _load();
+
+    if (_videoSettings) {
+        connect(_videoSettings->lowLatencyMode(), &Fact::rawValueChanged, this, &CameraManagerPlugin::_onLowLatencyChanged, Qt::UniqueConnection);
+    }
+
+    _updateMainStream();
+    _updateSecondaryReceivers();
+}
+
+CameraManagerPlugin::~CameraManagerPlugin()
+{
+    for (CameraEntry &entry : _cameras) {
+        _destroyReceiver(entry);
+    }
+}
+
+QVariantList CameraManagerPlugin::cameras() const
+{
+    QVariantList result;
+    const int cameraCount = static_cast<int>(_cameras.size());
+    result.reserve(cameraCount);
+
+    for (int index = 0; index < cameraCount; ++index) {
+        const CameraEntry &entry = _cameras.at(static_cast<std::size_t>(index));
+        QVariantMap map;
+        map.insert(QStringLiteral("name"), entry.name);
+        map.insert(QStringLiteral("url"), entry.url);
+        map.insert(QStringLiteral("index"), index);
+        map.insert(QStringLiteral("isPrimary"), index == _primaryIndex);
+        result.append(map);
+    }
+
+    return result;
+}
+
+QVariantList CameraManagerPlugin::secondaryCameras() const
+{
+    QVariantList result;
+    const int cameraCount = static_cast<int>(_cameras.size());
+    result.reserve(cameraCount);
+
+    for (int index = 0; index < cameraCount; ++index) {
+        if (index == _primaryIndex) {
+            continue;
+        }
+        const CameraEntry &entry = _cameras.at(static_cast<std::size_t>(index));
+        QVariantMap map;
+        map.insert(QStringLiteral("name"), entry.name);
+        map.insert(QStringLiteral("url"), entry.url);
+        map.insert(QStringLiteral("index"), index);
+        result.append(map);
+    }
+
+    return result;
+}
+
+void CameraManagerPlugin::addCamera(const QString &name, const QString &url)
+{
+    const QString trimmedName = name.trimmed();
+    const QString trimmedUrl = url.trimmed();
+    if (trimmedName.isEmpty() || trimmedUrl.isEmpty()) {
+        qCWarning(CustomCameraManagerLog) << "Ignoring camera with empty name or URL";
+        return;
+    }
+
+    CameraEntry entry;
+    entry.name = trimmedName;
+    entry.url = trimmedUrl;
+    _cameras.push_back(std::move(entry));
+
+    if (_primaryIndex < 0) {
+        _primaryIndex = static_cast<int>(_cameras.size()) - 1;
+        emit primaryIndexChanged();
+    }
+
+    _save();
+    _emitListsChanged();
+    _updateMainStream();
+    _updateSecondaryReceivers();
+}
+
+void CameraManagerPlugin::updateCamera(int index, const QString &name, const QString &url)
+{
+    CameraEntry *entry = _entryForIndex(index);
+    if (!entry) {
+        qCWarning(CustomCameraManagerLog) << "Attempted to update invalid camera index" << index;
+        return;
+    }
+
+    const QString trimmedName = name.trimmed();
+    const QString trimmedUrl = url.trimmed();
+    if (trimmedName.isEmpty() || trimmedUrl.isEmpty()) {
+        qCWarning(CustomCameraManagerLog) << "Ignoring update with empty name or URL";
+        return;
+    }
+
+    entry->name = trimmedName;
+    entry->url = trimmedUrl;
+
+    if (entry->receiver) {
+        entry->receiver->setUri(entry->url);
+    }
+
+    _save();
+    _emitListsChanged();
+
+    if (index == _primaryIndex) {
+        _updateMainStream();
+    }
+
+    _updateSecondaryReceivers();
+}
+
+void CameraManagerPlugin::removeCamera(int index)
+{
+    if (index < 0 || index >= static_cast<int>(_cameras.size())) {
+        qCWarning(CustomCameraManagerLog) << "Attempted to remove invalid camera index" << index;
+        return;
+    }
+
+    _destroyReceiver(_cameras[static_cast<std::size_t>(index)]);
+    _cameras.erase(_cameras.begin() + static_cast<std::size_t>(index));
+
+    if (_primaryIndex == index) {
+        _primaryIndex = -1;
+        emit primaryIndexChanged();
+    } else if (_primaryIndex > index) {
+        _primaryIndex -= 1;
+        emit primaryIndexChanged();
+    }
+
+    _ensurePrimaryValid();
+    _save();
+    _emitListsChanged();
+    _updateMainStream();
+    _updateSecondaryReceivers();
+}
+
+QVariantMap CameraManagerPlugin::cameraAt(int index) const
+{
+    QVariantMap map;
+    const CameraEntry *entry = _entryForIndex(index);
+    if (!entry) {
+        return map;
+    }
+
+    map.insert(QStringLiteral("name"), entry->name);
+    map.insert(QStringLiteral("url"), entry->url);
+    map.insert(QStringLiteral("index"), index);
+    map.insert(QStringLiteral("isPrimary"), index == _primaryIndex);
+
+    return map;
+}
+
+void CameraManagerPlugin::promoteToPrimary(int index)
+{
+    if (index == _primaryIndex) {
+        return;
+    }
+
+    if (!_entryForIndex(index)) {
+        qCWarning(CustomCameraManagerLog) << "Attempted to promote invalid camera index" << index;
+        return;
+    }
+
+    _setPrimaryIndex(index);
+    _save();
+    _updateMainStream();
+    _updateSecondaryReceivers();
+    _emitListsChanged();
+}
+
+void CameraManagerPlugin::toggleSecondaryStreams()
+{
+    setSecondaryStreamsVisible(!_secondaryStreamsVisible);
+}
+
+void CameraManagerPlugin::registerView(int index, QQuickItem *item)
+{
+    if (!item) {
+        return;
+    }
+
+    CameraEntry *entry = _entryForIndex(index);
+    if (!entry) {
+        qCWarning(CustomCameraManagerLog) << "Attempted to register view for invalid camera index" << index;
+        return;
+    }
+
+    if (entry->widget && entry->widget != item) {
+        unregisterView(index, entry->widget.data());
+    }
+
+    if (entry->widget == item) {
+        return;
+    }
+
+    entry->widget = item;
+
+    if (!entry->receiver) {
+        _createReceiver(*entry);
+    }
+
+    if (!entry->receiver) {
+        return;
+    }
+
+    entry->receiver->setWidget(item);
+
+    if (entry->sink) {
+        QGCCorePlugin::instance()->releaseVideoSink(entry->sink);
+        entry->sink = nullptr;
+    }
+
+    entry->sink = QGCCorePlugin::instance()->createVideoSink(item, entry->receiver.get());
+    if (!entry->sink) {
+        qCWarning(CustomCameraManagerLog) << "Failed to create sink for camera" << entry->name;
+        return;
+    }
+
+    entry->receiver->setSink(entry->sink);
+
+    if (_secondaryStreamsVisible && index != _primaryIndex) {
+        _startReceiver(*entry);
+    }
+}
+
+void CameraManagerPlugin::unregisterView(int index, QQuickItem *item)
+{
+    CameraEntry *entry = _entryForIndex(index);
+    if (!entry) {
+        return;
+    }
+
+    if (item && entry->widget != item) {
+        return;
+    }
+
+    if (entry->receiver) {
+        entry->receiver->stopDecoding();
+        entry->receiver->stop();
+        entry->receiver->setWidget(nullptr);
+        entry->receiver->setSink(nullptr);
+    }
+
+    if (entry->sink) {
+        QGCCorePlugin::instance()->releaseVideoSink(entry->sink);
+        entry->sink = nullptr;
+    }
+
+    entry->widget = nullptr;
+}
+
+void CameraManagerPlugin::setSecondaryStreamsVisible(bool visible)
+{
+    const bool canShow = visible && hasSecondaryStreams();
+    if (canShow == _secondaryStreamsVisible) {
+        return;
+    }
+
+    _secondaryStreamsVisible = canShow;
+    _updateSecondaryReceivers();
+    emit secondaryStreamsVisibleChanged();
+}
+
+void CameraManagerPlugin::_load()
+{
+    _cameras.clear();
+
+    QSettings settings;
+    settings.beginGroup(QLatin1String(kSettingsGroup));
+    const QString raw = settings.value(QLatin1String(kStreamsKey)).toString();
+    const int storedPrimary = settings.value(QLatin1String(kPrimaryKey), 0).toInt();
+    settings.endGroup();
+
+    if (!raw.isEmpty()) {
+        const QJsonDocument document = QJsonDocument::fromJson(raw.toUtf8());
+        if (document.isArray()) {
+            const QJsonArray array = document.array();
+            for (const QJsonValue &value : array) {
+                if (!value.isObject()) {
+                    continue;
+                }
+
+                const QJsonObject object = value.toObject();
+                CameraEntry entry;
+                entry.name = object.value(QStringLiteral("name")).toString();
+                entry.url = object.value(QStringLiteral("url")).toString();
+                if (entry.name.isEmpty() || entry.url.isEmpty()) {
+                    continue;
+                }
+                _cameras.push_back(std::move(entry));
+            }
+        } else {
+            qCWarning(CustomCameraManagerLog) << "Camera settings payload is not an array";
+        }
+    }
+
+    if (_cameras.empty()) {
+        _primaryIndex = -1;
+    } else {
+        const int maxIndex = static_cast<int>(_cameras.size()) - 1;
+        _primaryIndex = qBound(0, storedPrimary, maxIndex);
+    }
+
+    emit primaryIndexChanged();
+    _emitListsChanged();
+}
+
+void CameraManagerPlugin::_save() const
+{
+    QJsonArray array;
+    for (const CameraEntry &entry : _cameras) {
+        QJsonObject object;
+        object.insert(QStringLiteral("name"), entry.name);
+        object.insert(QStringLiteral("url"), entry.url);
+        array.append(object);
+    }
+
+    QSettings settings;
+    settings.beginGroup(QLatin1String(kSettingsGroup));
+    settings.setValue(QLatin1String(kStreamsKey), QString::fromUtf8(QJsonDocument(array).toJson(QJsonDocument::Compact)));
+    settings.setValue(QLatin1String(kPrimaryKey), _primaryIndex);
+    settings.endGroup();
+}
+
+void CameraManagerPlugin::_ensurePrimaryValid()
+{
+    if (_cameras.empty()) {
+        if (_primaryIndex != -1) {
+            _primaryIndex = -1;
+            emit primaryIndexChanged();
+        }
+        return;
+    }
+
+    if (_primaryIndex < 0 || _primaryIndex >= static_cast<int>(_cameras.size())) {
+        _primaryIndex = 0;
+        emit primaryIndexChanged();
+    }
+}
+
+void CameraManagerPlugin::_updateMainStream()
+{
+    if (!_videoSettings) {
+        return;
+    }
+
+    if (_primaryIndex < 0 || _primaryIndex >= static_cast<int>(_cameras.size())) {
+        _videoSettings->streamEnabled()->setRawValue(false);
+        _videoSettings->videoSource()->setRawValue(VideoSettings::videoDisabled);
+        return;
+    }
+
+    const CameraEntry &entry = _cameras.at(static_cast<std::size_t>(_primaryIndex));
+    _videoSettings->videoSource()->setRawValue(VideoSettings::videoSourceRTSP);
+    _videoSettings->rtspUrl()->setRawValue(entry.url);
+    _videoSettings->streamEnabled()->setRawValue(true);
+}
+
+void CameraManagerPlugin::_updateSecondaryReceivers()
+{
+    const int cameraCount = static_cast<int>(_cameras.size());
+    for (int index = 0; index < cameraCount; ++index) {
+        CameraEntry &entry = _cameras[static_cast<std::size_t>(index)];
+        if (index == _primaryIndex || !_secondaryStreamsVisible) {
+            _stopReceiver(entry);
+            continue;
+        }
+
+        if (!entry.receiver || !entry.widget || !entry.sink) {
+            continue;
+        }
+
+        _startReceiver(entry);
+    }
+
+    emit secondaryCamerasChanged();
+}
+
+void CameraManagerPlugin::_startReceiver(CameraEntry &entry)
+{
+    if (!entry.receiver || !entry.widget || !entry.sink) {
+        return;
+    }
+
+    if (entry.url.isEmpty()) {
+        return;
+    }
+
+    _applyLowLatency(entry);
+    entry.receiver->setUri(entry.url);
+
+    uint32_t timeout = 3;
+    if (_videoSettings && _videoSettings->rtspTimeout()) {
+        timeout = _videoSettings->rtspTimeout()->rawValue().toUInt();
+        if (timeout == 0) {
+            timeout = 3;
+        }
+    }
+
+    entry.receiver->start(timeout);
+}
+
+void CameraManagerPlugin::_stopReceiver(CameraEntry &entry)
+{
+    if (!entry.receiver) {
+        return;
+    }
+
+    entry.receiver->stopDecoding();
+    entry.receiver->stop();
+}
+
+void CameraManagerPlugin::_createReceiver(CameraEntry &entry)
+{
+    if (entry.receiver) {
+        _applyLowLatency(entry);
+        return;
+    }
+
+    VideoReceiver *receiver = QGCCorePlugin::instance()->createVideoReceiver(this);
+    if (!receiver) {
+        qCWarning(CustomCameraManagerLog) << "Unable to create VideoReceiver for camera" << entry.name;
+        return;
+    }
+
+    receiver->setName(QStringLiteral("camera_%1").arg(entry.name));
+    receiver->setUri(entry.url);
+
+    entry.receiver.reset(receiver);
+    _applyLowLatency(entry);
+
+    connect(receiver, &VideoReceiver::onStartComplete, this, [this, receiver](VideoReceiver::STATUS status) {
+        if (status != VideoReceiver::STATUS_OK) {
+            return;
+        }
+
+        const int index = _indexForReceiver(receiver);
+        if (index < 0 || index == _primaryIndex) {
+            return;
+        }
+
+        CameraEntry &entry = _cameras[static_cast<std::size_t>(index)];
+        if (entry.sink) {
+            receiver->startDecoding(entry.sink);
+        }
+    });
+
+    connect(receiver, &VideoReceiver::onStopComplete, this, [this, receiver](VideoReceiver::STATUS status) {
+        if (status == VideoReceiver::STATUS_INVALID_URL) {
+            return;
+        }
+
+        const int index = _indexForReceiver(receiver);
+        if (index < 0) {
+            return;
+        }
+
+        if (!_secondaryStreamsVisible || index == _primaryIndex) {
+            return;
+        }
+
+        QTimer::singleShot(1000, receiver, [this, receiver]() {
+            const int innerIndex = _indexForReceiver(receiver);
+            if (innerIndex < 0 || innerIndex == _primaryIndex || !_secondaryStreamsVisible) {
+                return;
+            }
+
+            CameraEntry &entry = _cameras[static_cast<std::size_t>(innerIndex)];
+            if (entry.sink && entry.widget) {
+                _startReceiver(entry);
+            }
+        });
+    });
+
+    // entry.receiver already owns receiver
+}
+
+void CameraManagerPlugin::_destroyReceiver(CameraEntry &entry)
+{
+    if (entry.receiver) {
+        entry.receiver->stopDecoding();
+        entry.receiver->stop();
+        entry.receiver.reset();
+    }
+
+    if (entry.sink) {
+        QGCCorePlugin::instance()->releaseVideoSink(entry.sink);
+        entry.sink = nullptr;
+    }
+
+    entry.widget = nullptr;
+}
+
+void CameraManagerPlugin::_applyLowLatency(CameraEntry &entry)
+{
+    if (!entry.receiver || !_videoSettings) {
+        return;
+    }
+
+    entry.receiver->setLowLatency(_videoSettings->lowLatencyMode()->rawValue().toBool());
+}
+
+void CameraManagerPlugin::_onLowLatencyChanged(const QVariant &value)
+{
+    Q_UNUSED(value);
+
+    for (CameraEntry &entry : _cameras) {
+        _applyLowLatency(entry);
+    }
+}
+
+void CameraManagerPlugin::_setPrimaryIndex(int index)
+{
+    if (index == _primaryIndex) {
+        return;
+    }
+
+    _primaryIndex = index;
+    emit primaryIndexChanged();
+}
+
+void CameraManagerPlugin::_emitListsChanged()
+{
+    emit camerasChanged();
+    emit secondaryCamerasChanged();
+
+    if (_secondaryStreamsVisible && !hasSecondaryStreams()) {
+        _secondaryStreamsVisible = false;
+        emit secondaryStreamsVisibleChanged();
+    }
+}
+
+int CameraManagerPlugin::_indexForReceiver(VideoReceiver *receiver) const
+{
+    if (!receiver) {
+        return -1;
+    }
+
+    const int cameraCount = static_cast<int>(_cameras.size());
+    for (int index = 0; index < cameraCount; ++index) {
+        const CameraEntry &entry = _cameras.at(static_cast<std::size_t>(index));
+        if (entry.receiver.get() == receiver) {
+            return index;
+        }
+    }
+
+    return -1;
+}
+
+CameraManagerPlugin::CameraEntry *CameraManagerPlugin::_entryForIndex(int index)
+{
+    if (index < 0 || index >= static_cast<int>(_cameras.size())) {
+        return nullptr;
+    }
+
+    return &_cameras[static_cast<std::size_t>(index)];
+}
+
+const CameraManagerPlugin::CameraEntry *CameraManagerPlugin::_entryForIndex(int index) const
+{
+    if (index < 0 || index >= static_cast<int>(_cameras.size())) {
+        return nullptr;
+    }
+
+    return &_cameras[static_cast<std::size_t>(index)];
+}

--- a/custom/src/CameraManagerPlugin.h
+++ b/custom/src/CameraManagerPlugin.h
@@ -1,0 +1,91 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <QtCore/QObject>
+#include <QtCore/QPointer>
+#include <QtCore/QVariantList>
+
+#include <memory>
+#include <vector>
+
+class QQuickItem;
+class VideoReceiver;
+class VideoSettings;
+
+class CameraManagerPlugin : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QVariantList cameras READ cameras NOTIFY camerasChanged FINAL)
+    Q_PROPERTY(QVariantList secondaryCameras READ secondaryCameras NOTIFY secondaryCamerasChanged FINAL)
+    Q_PROPERTY(int primaryIndex READ primaryIndex NOTIFY primaryIndexChanged FINAL)
+    Q_PROPERTY(bool secondaryStreamsVisible READ secondaryStreamsVisible WRITE setSecondaryStreamsVisible NOTIFY secondaryStreamsVisibleChanged FINAL)
+    Q_PROPERTY(bool hasCameras READ hasCameras NOTIFY camerasChanged FINAL)
+    Q_PROPERTY(bool hasSecondaryStreams READ hasSecondaryStreams NOTIFY camerasChanged FINAL)
+
+public:
+    explicit CameraManagerPlugin(QObject *parent = nullptr);
+    ~CameraManagerPlugin() override;
+
+    QVariantList cameras() const;
+    QVariantList secondaryCameras() const;
+    int primaryIndex() const { return _primaryIndex; }
+    bool secondaryStreamsVisible() const { return _secondaryStreamsVisible; }
+    bool hasCameras() const { return !_cameras.empty(); }
+    bool hasSecondaryStreams() const { return _cameras.size() > 1; }
+
+    Q_INVOKABLE void addCamera(const QString &name, const QString &url);
+    Q_INVOKABLE void updateCamera(int index, const QString &name, const QString &url);
+    Q_INVOKABLE void removeCamera(int index);
+    Q_INVOKABLE QVariantMap cameraAt(int index) const;
+    Q_INVOKABLE void promoteToPrimary(int index);
+    Q_INVOKABLE void toggleSecondaryStreams();
+    Q_INVOKABLE void registerView(int index, QQuickItem *item);
+    Q_INVOKABLE void unregisterView(int index, QQuickItem *item = nullptr);
+
+    void setSecondaryStreamsVisible(bool visible);
+
+signals:
+    void camerasChanged();
+    void secondaryCamerasChanged();
+    void primaryIndexChanged();
+    void secondaryStreamsVisibleChanged();
+
+private:
+    struct CameraEntry {
+        QString name;
+        QString url;
+        std::unique_ptr<VideoReceiver> receiver;
+        QPointer<QQuickItem> widget;
+        void *sink = nullptr;
+    };
+
+    void _load();
+    void _save() const;
+    void _ensurePrimaryValid();
+    void _updateMainStream();
+    void _updateSecondaryReceivers();
+    void _startReceiver(CameraEntry &entry);
+    void _stopReceiver(CameraEntry &entry);
+    void _createReceiver(CameraEntry &entry);
+    void _destroyReceiver(CameraEntry &entry);
+    void _applyLowLatency(CameraEntry &entry);
+    void _onLowLatencyChanged(const QVariant &value);
+    void _setPrimaryIndex(int index);
+    void _emitListsChanged();
+    int _indexForReceiver(VideoReceiver *receiver) const;
+    CameraEntry *_entryForIndex(int index);
+    const CameraEntry *_entryForIndex(int index) const;
+
+    std::vector<CameraEntry> _cameras;
+    int _primaryIndex = -1;
+    bool _secondaryStreamsVisible = false;
+    VideoSettings *_videoSettings = nullptr;
+};

--- a/custom/src/CameraManagerSettings.qml
+++ b/custom/src/CameraManagerSettings.qml
@@ -1,0 +1,194 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import QGroundControl
+import QGroundControl.Controls
+
+Item {
+    id: root
+
+    readonly property var manager: QGroundControl.corePlugin ? QGroundControl.corePlugin.cameraManager : null
+
+    property string cameraName: ""
+    property string cameraUrl: ""
+    property int editingIndex: -1
+
+    QGCPalette { id: qgcPal; colorGroupEnabled: true }
+
+    function startNewCamera() {
+        editingIndex = -1
+        cameraName = ""
+        cameraUrl = ""
+    }
+
+    function editCamera(index) {
+        if (!manager) {
+            return
+        }
+
+        const data = manager.cameraAt(index)
+        if (!data || data.name === undefined) {
+            return
+        }
+
+        editingIndex = index
+        cameraName = data.name
+        cameraUrl = data.url
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: ScreenTools.defaultFontPixelWidth
+        spacing: ScreenTools.defaultFontPixelHeight
+
+        SectionHeader {
+            text: qsTr("Camera manager")
+        }
+
+        QGCLabel {
+            wrapMode: Text.WordWrap
+            text: qsTr("Configure RTSP video streams used by the Camera manager plugin. The first saved camera is used as the primary video stream by default.")
+        }
+
+        RowLayout {
+            spacing: ScreenTools.defaultFontPixelWidth
+
+            QGCButton {
+                text: qsTr("Add new")
+                onClicked: startNewCamera()
+            }
+
+            QGCButton {
+                text: editingIndex >= 0 ? qsTr("Save changes") : qsTr("Save")
+                enabled: manager && cameraName.trim().length > 0 && cameraUrl.trim().length > 0
+                onClicked: {
+                    if (!manager) {
+                        return
+                    }
+
+                    if (editingIndex >= 0) {
+                        manager.updateCamera(editingIndex, cameraName, cameraUrl)
+                    } else {
+                        manager.addCamera(cameraName, cameraUrl)
+                    }
+                    startNewCamera()
+                }
+            }
+
+            QGCButton {
+                text: qsTr("Cancel")
+                visible: editingIndex >= 0
+                onClicked: startNewCamera()
+            }
+        }
+
+        GridLayout {
+            columns: 2
+            columnSpacing: ScreenTools.defaultFontPixelWidth
+            rowSpacing: ScreenTools.defaultFontPixelHeight / 2
+
+            QGCLabel {
+                text: qsTr("Camera name")
+            }
+
+            QGCTextField {
+                text: root.cameraName
+                onTextChanged: root.cameraName = text
+                placeholderText: qsTr("e.g. Front camera")
+                Layout.fillWidth: true
+            }
+
+            QGCLabel {
+                text: qsTr("URL")
+            }
+
+            QGCTextField {
+                text: root.cameraUrl
+                onTextChanged: root.cameraUrl = text
+                placeholderText: qsTr("rtsp://example/stream")
+                Layout.fillWidth: true
+            }
+        }
+
+        Item { Layout.preferredHeight: ScreenTools.defaultFontPixelHeight / 2 }
+
+        Repeater {
+            id: cameraRepeater
+            model: manager ? manager.cameras : []
+
+            delegate: Frame {
+                Layout.fillWidth: true
+                Layout.preferredHeight: implicitHeight
+                padding: ScreenTools.defaultFontPixelHeight / 2
+
+                ColumnLayout {
+                    width: parent.width
+                    spacing: ScreenTools.defaultFontPixelHeight / 2
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: ScreenTools.defaultFontPixelWidth
+
+                        QGCLabel {
+                            text: modelData.name
+                            font.bold: modelData.isPrimary
+                            Layout.fillWidth: true
+                        }
+
+                        QGCLabel {
+                            text: modelData.isPrimary ? qsTr("Primary") : ""
+                            font.bold: true
+                            visible: modelData.isPrimary
+                        }
+                    }
+
+                    QGCLabel {
+                        text: modelData.url
+                        color: qgcPal.text
+                        font.pointSize: ScreenTools.defaultFontPointSize
+                        wrapMode: Text.WrapAnywhere
+                        Layout.fillWidth: true
+                    }
+
+                    RowLayout {
+                        spacing: ScreenTools.defaultFontPixelWidth
+
+                        QGCButton {
+                            text: qsTr("Edit")
+                            onClicked: editCamera(modelData.index)
+                        }
+
+                        QGCButton {
+                            text: qsTr("Remove")
+                            onClicked: manager.removeCamera(modelData.index)
+                        }
+
+                        QGCButton {
+                            text: qsTr("Set as main")
+                            visible: !modelData.isPrimary
+                            onClicked: manager.promoteToPrimary(modelData.index)
+                        }
+                    }
+                }
+            }
+        }
+
+        QGCLabel {
+            visible: !manager || manager.cameras.length === 0
+            text: qsTr("No cameras configured yet.")
+            font.italic: true
+        }
+
+        Item { Layout.fillHeight: true }
+    }
+}

--- a/custom/src/CameraStreamView.qml
+++ b/custom/src/CameraStreamView.qml
@@ -1,0 +1,161 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick
+import QtQuick.Controls
+import QGroundControl
+import QGroundControl.Controls
+import QGroundControl.FlightDisplay
+
+Item {
+    id: root
+    width: ScreenTools.defaultFontPixelWidth * 13
+    height: width * 0.65
+    clip: true
+
+    property int streamIndex: -1
+    property string streamName: ""
+    property var cameraManager: null
+
+    readonly property bool gstreamerAvailable: QGroundControl.videoManager.gstreamerEnabled
+    readonly property bool qtMultimediaAvailable: QGroundControl.videoManager.qtmultimediaEnabled
+    readonly property bool hasVideoBackend: gstreamerAvailable || qtMultimediaAvailable
+
+    property int _registeredIndex: -1
+    property var _registeredItem: null
+
+    QGCPalette { id: qgcPal; colorGroupEnabled: true }
+
+    function unregisterStream() {
+        if (!cameraManager || _registeredIndex < 0) {
+            _registeredIndex = -1
+            _registeredItem = null
+            return
+        }
+
+        cameraManager.unregisterView(_registeredIndex)
+        _registeredIndex = -1
+        _registeredItem = null
+    }
+
+    function registerStream() {
+        if (!cameraManager || !hasVideoBackend || streamIndex < 0 || !videoLoader.item) {
+            if (_registeredIndex >= 0) {
+                unregisterStream()
+            }
+            return
+        }
+
+        if (_registeredIndex === streamIndex && _registeredItem === videoLoader.item) {
+            return
+        }
+
+        if (_registeredIndex >= 0) {
+            unregisterStream()
+        }
+
+        cameraManager.registerView(streamIndex, videoLoader.item)
+        _registeredIndex = streamIndex
+        _registeredItem = videoLoader.item
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        radius: ScreenTools.defaultFontPixelWidth / 3
+        color: qgcPal.windowShadeDark
+        border.color: qgcPal.windowShade
+        border.width: 1
+    }
+
+    Loader {
+        id: videoLoader
+        anchors.fill: parent
+        active: hasVideoBackend
+        sourceComponent: gstreamerAvailable ? gstreamerComponent : (qtMultimediaAvailable ? qtMultimediaComponent : null)
+        onStatusChanged: {
+            if (status === Loader.Ready) {
+                registerStream()
+            } else if (status === Loader.Null || status === Loader.Error) {
+                unregisterStream()
+            }
+        }
+    }
+
+    Component {
+        id: gstreamerComponent
+
+        FlightDisplayViewGStreamer {
+            anchors.fill: parent
+            antialiasing: true
+        }
+    }
+
+    Component {
+        id: qtMultimediaComponent
+
+        FlightDisplayViewQtMultimedia {
+            anchors.fill: parent
+        }
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        color: qgcPal.windowShadeDark
+        border.color: qgcPal.windowShade
+        border.width: 1
+        visible: !hasVideoBackend
+
+        QGCLabel {
+            text: qsTr("Video preview unavailable")
+            anchors.centerIn: parent
+            color: qgcPal.text
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
+            width: parent.width - ScreenTools.defaultFontPixelWidth * 2
+        }
+    }
+
+    Rectangle {
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        color: Qt.rgba(qgcPal.window.r, qgcPal.window.g, qgcPal.window.b, 0.65)
+        height: streamLabel.implicitHeight + ScreenTools.defaultFontPixelHeight / 4
+
+        QGCLabel {
+            id: streamLabel
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.verticalCenter: parent.verticalCenter
+            text: streamName
+            font.pointSize: ScreenTools.smallFontPointSize
+            elide: Text.ElideRight
+            width: root.width - ScreenTools.defaultFontPixelWidth
+            horizontalAlignment: Text.AlignHCenter
+        }
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        onClicked: {
+            if (cameraManager && streamIndex >= 0) {
+                cameraManager.promoteToPrimary(streamIndex)
+            }
+        }
+    }
+
+    Component.onCompleted: registerStream()
+
+    onCameraManagerChanged: registerStream()
+    onStreamIndexChanged: registerStream()
+    onHasVideoBackendChanged: hasVideoBackend ? registerStream() : unregisterStream()
+    onGstreamerAvailableChanged: registerStream()
+    onQtMultimediaAvailableChanged: registerStream()
+
+    Component.onDestruction: unregisterStream()
+}

--- a/custom/src/CustomPlugin.cc
+++ b/custom/src/CustomPlugin.cc
@@ -9,6 +9,7 @@
 
 #include "CustomPlugin.h"
 
+#include "CameraManagerPlugin.h"
 #include "QGCLoggingCategory.h"
 #include "MultiVehicleManager.h"
 #include "MAVLinkProtocol.h"
@@ -37,6 +38,7 @@ Q_APPLICATION_STATIC(CustomPlugin, _customPluginInstance);
 CustomPlugin::CustomPlugin(QObject *parent)
     : QGCCorePlugin(parent)
 {
+    _cameraManager = new CameraManagerPlugin(this);
     _loadServoButtons();
 
     emit servoButtonsChanged();

--- a/custom/src/CustomPlugin.h
+++ b/custom/src/CustomPlugin.h
@@ -14,6 +14,7 @@
 #include <QtQml/QQmlAbstractUrlInterceptor>
 
 #include "QGCCorePlugin.h"
+#include "CameraManagerPlugin.h"
 
 class QQmlApplicationEngine;
 
@@ -31,6 +32,7 @@ class CustomPlugin : public QGCCorePlugin
 {
     Q_OBJECT
     Q_PROPERTY(QVariantList servoButtons READ servoButtons NOTIFY servoButtonsChanged FINAL)
+    Q_PROPERTY(CameraManagerPlugin *cameraManager READ cameraManager CONSTANT FINAL)
 
 public:
     explicit CustomPlugin(QObject *parent = nullptr);
@@ -39,6 +41,7 @@ public:
     static QGCCorePlugin *instance();
 
     QVariantList servoButtons() const;
+    CameraManagerPlugin *cameraManager() const { return _cameraManager; }
 
     Q_INVOKABLE void addServoButton(const QString &name, int channel, int pulseWidth);
     Q_INVOKABLE void updateServoButton(int index, const QString &name, int channel, int pulseWidth);
@@ -70,4 +73,5 @@ private:
 
     CustomUrlInterceptor *_urlInterceptor = nullptr;
     QQmlApplicationEngine *_qmlEngine = nullptr;
+    CameraManagerPlugin *_cameraManager = nullptr;
 };

--- a/custom/src/FlightMap/Widgets/PhotoVideoControl.qml
+++ b/custom/src/FlightMap/Widgets/PhotoVideoControl.qml
@@ -1,0 +1,615 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick
+import QtPositioning
+import QtQuick.Layouts
+import QtQuick.Controls
+import QtQuick.Dialogs
+
+import QGroundControl
+
+import QGroundControl.Controls
+
+
+
+
+import QGroundControl.FactControls
+
+Rectangle {
+    width:      mainLayout.width + (_margins * 2)
+    height:     mainLayout.height + (_margins * 2)
+    color:      Qt.rgba(qgcPal.window.r, qgcPal.window.g, qgcPal.window.b, 0.5)
+    radius:     _margins
+    visible:    _camera.capturesVideo || _camera.capturesPhotos
+
+    property real   _margins:                   ScreenTools.defaultFontPixelHeight / 2
+    property real   _smallMargins:              ScreenTools.defaultFontPixelWidth / 2
+    property var    _activeVehicle:             globals.activeVehicle
+    property var    _cameraManager:             _activeVehicle.cameraManager
+    property var    _camera:                    _cameraManager.currentCameraInstance
+    property var    _customCameraManager:       QGroundControl.corePlugin ? QGroundControl.corePlugin.cameraManager : null
+    property bool   _cameraInPhotoMode:         _camera.cameraMode === MavlinkCameraControl.CAM_MODE_PHOTO
+    property bool   _cameraInVideoMode:         !_cameraInPhotoMode
+    property bool   _videoCaptureIdle:          _camera.videoCaptureStatus === MavlinkCameraControl.VIDEO_CAPTURE_STATUS_STOPPED
+    property bool   _photoCaptureSingleIdle:    _camera.photoCaptureStatus === MavlinkCameraControl.PHOTO_CAPTURE_IDLE
+    property bool   _photoCaptureIntervalIdle:  _camera.photoCaptureStatus === MavlinkCameraControl.PHOTO_CAPTURE_INTERVAL_IDLE
+    property bool   _photoCaptureIdle:          _photoCaptureSingleIdle || _photoCaptureIntervalIdle
+    property bool   _secondaryStreamsActive:    _customCameraManager ? _customCameraManager.secondaryStreamsVisible : false
+    property bool   _hasSecondaryStreams:       _customCameraManager ? _customCameraManager.hasSecondaryStreams : false
+
+    QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
+
+    DeadMouseArea { anchors.fill: parent }
+
+    RowLayout {
+        id:                 mainLayout
+        anchors.margins:    _margins
+        anchors.top:        parent.top
+        anchors.left:       parent.left
+        spacing:            _margins
+
+        ColumnLayout {
+            Layout.fillHeight:  true
+            spacing:            _margins
+            visible:            _camera.hasZoom
+
+            QGCLabel {
+                Layout.alignment:   Qt.AlignHCenter
+                text:               qsTr("Zoom")
+                font.pointSize:     ScreenTools.smallFontPointSize
+            }
+
+            QGCSlider {
+                Layout.alignment:   Qt.AlignHCenter
+                Layout.fillHeight:  true
+                orientation:        Qt.Vertical
+                to:                 100
+                from:               0
+                value:              _camera.zoomLevel
+                live:               true
+                onValueChanged:     _camera.zoomLevel = value
+            }
+        }
+        
+        ColumnLayout {
+            spacing: _margins * 2
+
+            ColumnLayout {
+                spacing: _margins
+
+                // Camera name
+                QGCLabel {
+                    Layout.alignment:   Qt.AlignHCenter
+                    text:               _camera.modelName
+                    visible:            _cameraManager.cameras.length > 1
+                }
+
+                // Photo/Video Mode Selector
+                Rectangle {
+                    Layout.alignment:   Qt.AlignHCenter
+                    width:              ScreenTools.defaultFontPixelWidth * 10
+                    height:             width / 2
+                    color:              qgcPal.windowShadeLight
+                    radius:             height * 0.5
+                    visible:            _camera.hasModes
+
+                    //-- Video Mode
+                    Rectangle {
+                        anchors.verticalCenter: parent.verticalCenter
+                        width:                  parent.height
+                        height:                 parent.height
+                        color:                  _cameraInVideoMode ? qgcPal.window : qgcPal.windowShadeLight
+                        radius:                 height * 0.5
+                        anchors.left:           parent.left
+                        border.color:           qgcPal.text
+                        border.width:           _cameraInPhotoMode ? 0 : 1
+
+                        QGCColoredImage {
+                            height:             parent.height * 0.5
+                            width:              height
+                            anchors.centerIn:   parent
+                            source:             "/qmlimages/camera_video.svg"
+                            fillMode:           Image.PreserveAspectFit
+                            sourceSize.height:  height
+                            color:              _cameraInVideoMode ? qgcPal.colorGreen : qgcPal.text
+
+                            MouseArea {
+                                anchors.fill:   parent
+                                enabled:        _cameraInPhotoMode ? _photoCaptureIdle : true
+                                onClicked:      _camera.setCameraModeVideo()
+                            }
+                        }
+                    }
+                    
+                    //-- Photo Mode
+                    Rectangle {
+                        anchors.verticalCenter: parent.verticalCenter
+                        width:                  parent.height
+                        height:                 parent.height
+                        color:                  _cameraInPhotoMode ? qgcPal.window : qgcPal.windowShadeLight
+                        radius:                 height * 0.5
+                        anchors.right:          parent.right
+                        border.color:           qgcPal.text
+                        border.width:           _cameraInPhotoMode ? 1 : 0
+
+                        QGCColoredImage {
+                            height:             parent.height * 0.5
+                            width:              height
+                            anchors.centerIn:   parent
+                            source:             "/qmlimages/camera_photo.svg"
+                            fillMode:           Image.PreserveAspectFit
+                            sourceSize.height:  height
+                            color:              _cameraInPhotoMode ? qgcPal.colorGreen : qgcPal.text
+
+                            MouseArea {
+                                anchors.fill:   parent
+                                enabled:        _cameraInVideoMode ? _videoCaptureIdle : true
+                                onClicked:      _camera.setCameraModePhoto()
+                            }
+                        }
+                    }
+                }
+
+                // Take Photo, Start/Stop Video button
+                Rectangle {
+                    Layout.alignment:   Qt.AlignHCenter
+                    color:              Qt.rgba(0,0,0,0)
+                    width:              ScreenTools.defaultFontPixelWidth * 6
+                    height:             width
+                    radius:             width * 0.5
+                    border.color:       qgcPal.buttonText
+                    border.width:       3
+
+                    Rectangle {
+                        // anchors.centerIn snaps to integer coordinates, which
+                        // depending on DPI can throw the centering off.
+                        // Setting alignWhenCentered to false avoids this issue.
+                        anchors {
+                            centerIn:           parent
+                            alignWhenCentered:  false
+                        }
+                        width:              parent.width * (_isShootingInCurrentMode ? 0.5 : 0.75)
+                        height:             width
+                        radius:             _isShootingInCurrentMode ? 0 : width * 0.5
+                        color:              _isShootingInCurrentMode || _canShootInCurrentMode ? qgcPal.colorRed : qgcPal.colorGrey
+
+                        property bool _isShootingInPhotoMode:   _cameraInPhotoMode && _camera.photoCaptureStatus === MavlinkCameraControl.PHOTO_CAPTURE_IN_PROGRESS
+                        property bool _isShootingInVideoMode:   (!_cameraInPhotoMode && _camera.videoCaptureStatus === MavlinkCameraControl.VIDEO_CAPTURE_STATUS_RUNNING)
+                        property bool _isShootingInCurrentMode: _cameraInPhotoMode ? _isShootingInPhotoMode : _isShootingInVideoMode
+                        property bool _isShootingInOtherMode:   _cameraInPhotoMode ? _isShootingInVideoMode : _isShootingInPhotoMode
+                        property bool _canShootInCurrentMode:   _isShootingInOtherMode ? 
+                                                                    (_cameraInPhotoMode ? _camera.photosInVideoMode : _camera.videoInPhotoMode) :
+                                                                    true
+                    }
+
+                    MouseArea {
+                        anchors.fill:   parent
+                        onClicked:      toggleShooting()
+
+                        function toggleShooting() {
+                            if (_cameraInPhotoMode) {
+                                if (_camera.photoCaptureStatus === MavlinkCameraControl.PHOTO_CAPTURE_INTERVAL_IN_PROGRESS) {
+                                    _camera.stopTakePhoto()
+                                } else if (_camera.photoCaptureStatus === MavlinkCameraControl.PHOTO_CAPTURE_IDLE || _camera.photoCaptureStatus === MavlinkCameraControl.PHOTO_CAPTURE_INTERVAL_IDLE) {
+                                    _camera.takePhoto()
+                                }
+                            } else {
+                                _camera.toggleVideoRecording()
+                            }
+                        }
+                    }
+                }
+
+                // Record time / Capture count
+                Rectangle {
+                    Layout.alignment:       Qt.AlignHCenter
+                    color:                  !_videoCaptureIdle && !_photoCaptureIdle ? "transparent" : qgcPal.colorRed
+                    Layout.preferredWidth:  (_cameraInVideoMode ? videoRecordTime.width : photoCaptureCount.width) + (_smallMargins * 2)
+                    Layout.preferredHeight: (_cameraInVideoMode ? videoRecordTime.height : photoCaptureCount.height)
+                    radius:                 _margins / 2
+
+                    // Video record time
+                    QGCLabel {
+                        id:                 videoRecordTime
+                        anchors.leftMargin: _smallMargins
+                        anchors.left:       parent.left
+                        anchors.top:        parent.top
+                        text:               _videoCaptureIdle ? "00:00:00" : _camera.recordTimeStr
+                        font.pointSize:     ScreenTools.largeFontPointSize
+                        visible:            _cameraInVideoMode
+                    }
+
+                    // Photo capture count
+                    QGCLabel {
+                        id:                 photoCaptureCount
+                        anchors.leftMargin: _smallMargins
+                        anchors.left:       parent.left
+                        anchors.top:        parent.top
+                        text:               _activeVehicle ? ('00000' + _activeVehicle.cameraTriggerPoints.count).slice(-5) : "00000"
+                        font.pointSize:     ScreenTools.largeFontPointSize
+                        visible:            _cameraInPhotoMode
+                    }
+                }
+
+                //-- Status Information
+                ColumnLayout {
+                    Layout.alignment:   Qt.AlignHCenter
+                    spacing:            0
+
+                    QGCLabel {
+                        Layout.alignment:   Qt.AlignHCenter
+                        text:               qsTr("Free Space: ") + _camera.storageFreeStr
+                        font.pointSize:     ScreenTools.defaultFontPointSize
+                        visible:            _camera.storageStatus === MavlinkCameraControl.STORAGE_READY
+                    }
+
+                    QGCLabel {
+                        Layout.alignment:   Qt.AlignHCenter
+                        text:               qsTr("Battery: ") + _camera.batteryRemainingStr
+                        font.pointSize:     ScreenTools.defaultFontPointSize
+                        visible:            _camera.batteryRemaining >= 0
+                    }
+                }
+            }
+
+            ColumnLayout {
+                id:                 trackingControls
+                Layout.alignment:   Qt.AlignHCenter
+                spacing:            _margins
+                visible:            _camera && _camera.hasTracking
+
+                Rectangle {
+                    Layout.alignment:       Qt.AlignHCenter
+                    color:                  _camera.trackingEnabled ? qgcPal.colorRed : qgcPal.windowShadeLight
+                    Layout.preferredWidth:  ScreenTools.defaultFontPixelWidth * 6
+                    Layout.preferredHeight: Layout.preferredWidth
+                    border.color:           qgcPal.buttonText
+                    border.width:           3
+                    
+                    QGCColoredImage {
+                        height:             parent.height * 0.5
+                        width:              height
+                        anchors.centerIn:   parent
+                        source:             "/qmlimages/TrackingIcon.svg"
+                        fillMode:           Image.PreserveAspectFit
+                        sourceSize.height:  height
+                        color:              qgcPal.text
+
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: {
+                                _camera.trackingEnabled = !_camera.trackingEnabled;
+                                if (!_camera.trackingEnabled) {
+                                    _camera.stopTracking()
+                                }
+                            }
+                        }
+                    }
+                }
+
+                QGCLabel {
+                    Layout.alignment:   Qt.AlignHCenter
+                    text:               qsTr("Camera Tracking")
+                    font.pointSize:     ScreenTools.defaultFontPointSize
+                    visible:            _camera && _camera.hasTracking
+                }
+            }
+
+            QGCColoredImage {
+                Layout.alignment:       Qt.AlignHCenter
+                source:                 "/res/gear-black.svg"
+                mipmap:                 true
+                Layout.preferredHeight: ScreenTools.defaultFontPixelHeight * 1.5
+                Layout.preferredWidth:  Layout.preferredHeight
+                sourceSize.height:      Layout.preferredHeight
+                color:                  qgcPal.text
+                fillMode:               Image.PreserveAspectFit
+
+                QGCMouseArea {
+                    fillItem:   parent
+                    onClicked:  settingsDialogComponent.createObject(mainWindow).open()
+                }
+            }
+
+            QGCColoredImage {
+                Layout.alignment:       Qt.AlignHCenter
+                source:                 _secondaryStreamsActive ? "qrc:/Custom/res/camera_toggle_on.svg" : "qrc:/Custom/res/camera_toggle_off.svg"
+                Layout.preferredHeight: ScreenTools.defaultFontPixelHeight * 1.6
+                Layout.preferredWidth:  Layout.preferredHeight
+                sourceSize.height:      Layout.preferredHeight
+                color:                  qgcPal.text
+                opacity:                _hasSecondaryStreams ? 1.0 : 0.35
+                fillMode:               Image.PreserveAspectFit
+
+                QGCMouseArea {
+                    fillItem:   parent
+                    enabled:    _hasSecondaryStreams
+                    onClicked: {
+                        if (_customCameraManager) {
+                            _customCameraManager.secondaryStreamsVisible = !_customCameraManager.secondaryStreamsVisible
+                        }
+                    }
+                }
+            }
+        }
+
+        Component {
+            id: settingsDialogComponent
+
+            QGCPopupDialog {
+                title:      qsTr("Settings")
+                buttons:    Dialog.Close
+
+                property bool _multipleMavlinkCameras:          _cameraManager.cameras.count > 1
+                property bool _multipleMavlinkCameraStreams:    _camera.streamLabels.length > 1
+                property bool _cameraStorageSupported:          _camera.storageStatus !== MavlinkCameraControl.STORAGE_NOT_SUPPORTED
+                property var  _videoSettings:                   QGroundControl.settingsManager.videoSettings
+
+                ColumnLayout {
+                    spacing: _margins
+
+                    GridLayout {
+                        id:     gridLayout
+                        flow:   GridLayout.TopToBottom
+                        rows:   dynamicRows + _camera.activeSettings.length
+
+                        property int dynamicRows: 10
+
+                        // First column
+                        QGCLabel {
+                            text:               qsTr("Camera")
+                            visible:            _multipleMavlinkCameras
+                            onVisibleChanged:   gridLayout.dynamicRows += visible ? 1 : -1
+                        }
+
+                        QGCLabel {
+                            text:               qsTr("Video Stream")
+                            visible:            _multipleMavlinkCameraStreams
+                            onVisibleChanged:   gridLayout.dynamicRows += visible ? 1 : -1
+                        }
+
+                        QGCLabel {
+                            text:               qsTr("Thermal View Mode")
+                            visible:            _camera.thermalStreamInstance
+                            onVisibleChanged:   gridLayout.dynamicRows += visible ? 1 : -1
+                        }
+
+                        QGCLabel {
+                            text:               qsTr("Blend Opacity")
+                            visible:            _camera.thermalStreamInstance && _camera.thermalMode === MavlinkCameraControl.THERMAL_BLEND
+                            onVisibleChanged:   gridLayout.dynamicRows += visible ? 1 : -1
+                        }
+
+                        // Mavlink Camera Protocol active settings
+                        Repeater {
+                            model: _camera.activeSettings
+
+                            QGCLabel {
+                                text: _camera.getFact(modelData).shortDescription
+                            }
+                        }
+
+                        QGCLabel {
+                            text:               qsTr("Photo Mode")
+                            visible:            _camera.capturesPhotos
+                            onVisibleChanged:   gridLayout.dynamicRows += visible ? 1 : -1
+                        }
+
+                        QGCLabel {
+                            text:               qsTr("Photo Interval (seconds)")
+                            visible:            _camera.capturesPhotos && _camera.photoCaptureMode === MavlinkCameraControl.PHOTO_CAPTURE_TIMELAPSE
+                            onVisibleChanged:   gridLayout.dynamicRows += visible ? 1 : -1
+                        }
+
+                        QGCLabel {
+                            text:               qsTr("Video Grid Lines")
+                            visible:            _camera.hasVideoStream
+                            onVisibleChanged:   gridLayout.dynamicRows += visible ? 1 : -1
+                        }
+
+                        QGCLabel {
+                            text:               qsTr("Video Screen Fit")
+                            visible:            _camera.hasVideoStream
+                            onVisibleChanged:   gridLayout.dynamicRows += visible ? 1 : -1
+                        }
+
+                        QGCLabel {
+                            text:               qsTr("Reset Camera Defaults")
+                            onVisibleChanged:   gridLayout.dynamicRows += visible ? 1 : -1
+                        }
+
+                        QGCLabel {
+                            text:               qsTr("Storage")
+                            visible:            _cameraStorageSupported
+                            onVisibleChanged:   gridLayout.dynamicRows += visible ? 1 : -1
+                        }
+
+                        // Second column
+                        QGCComboBox {
+                            Layout.fillWidth:   true
+                            sizeToContents:     true
+                            model:              _cameraManager.cameraLabels
+                            currentIndex:       _cameraManager.currentCamera
+                            visible:            _multipleMavlinkCameras
+                            onActivated:        (index) => { _cameraManager.currentCamera = index }
+                        }
+
+                        QGCComboBox {
+                            Layout.fillWidth:   true
+                            sizeToContents:     true
+                            model:              _camera.streamLabels
+                            currentIndex:       _camera.currentStream
+                            visible:            _multipleMavlinkCameraStreams
+                            onActivated:        (index) => { _camera.currentStream = index }
+                        }
+
+                        QGCComboBox {
+                            Layout.fillWidth:   true
+                            sizeToContents:     true
+                            model:              [ qsTr("Off"), qsTr("Blend"), qsTr("Full"), qsTr("Picture In Picture") ]
+                            currentIndex:       _camera.thermalMode
+                            visible:            _camera.thermalStreamInstance
+                            onActivated:        (index) => { _camera.thermalMode = index }
+                        }
+
+                        QGCSlider {
+                            Layout.fillWidth:   true
+                            to:                 100
+                            from:               0
+                            value:              _camera.thermalOpacity
+                            live:               true
+                            visible:            _camera.thermalStreamInstance && _camera.thermalMode === MavlinkCameraControl.THERMAL_BLEND
+                            onValueChanged:     _camera.thermalOpacity = value
+                        }
+
+                        // Mavlink Camera Protocol active settings
+                        Repeater {
+                            model: _camera.activeSettings
+
+                            RowLayout {
+                                Layout.fillWidth:   true
+                                spacing:            ScreenTools.defaultFontPixelWidth
+
+                                property var    _fact:      _camera.getFact(modelData)
+                                property bool   _isBool:    _fact.typeIsBool
+                                property bool   _isCombo:   !_isBool && _fact.enumStrings.length > 0
+                                property bool   _isSlider:  _fact && !isNaN(_fact.increment)
+                                property bool   _isEdit:    !_isBool && !_isSlider && _fact.enumStrings.length < 1
+
+                                FactComboBox {
+                                    Layout.fillWidth:   true
+                                    sizeToContents:     true
+                                    fact:               parent._fact
+                                    indexModel:         false
+                                    visible:            parent._isCombo
+                                }
+                                FactTextField {
+                                    Layout.fillWidth:   true
+                                    fact:               parent._fact
+                                    visible:            parent._isEdit
+                                }
+                                QGCSlider {
+                                    Layout.fillWidth:           true
+                                    to:               parent._fact.max
+                                    from:               parent._fact.min
+                                    stepSize:                   parent._fact.increment
+                                    visible:                    parent._isSlider
+                                    live:   false
+                                    property bool initialized:  false
+
+                                    onValueChanged: {
+                                        if (!initialized) {
+                                            return
+                                        }
+                                        parent._fact.value = value
+                                    }
+
+                                    Component.onCompleted: {
+                                        value = parent._fact.value
+                                        initialized = true
+                                    }
+                                }
+                                QGCSwitch {
+                                    checked:    parent._fact ? parent._fact.value : false
+                                    visible:    parent._isBool
+                                    onClicked:  parent._fact.value = checked ? 1 : 0
+                                }
+                            }
+                        }
+
+                        QGCComboBox {
+                            Layout.fillWidth:   true
+                            sizeToContents:     true
+                            model:              [ qsTr("Single"), qsTr("Time Lapse") ]
+                            currentIndex:       _camera.photoCaptureMode
+                            visible:            _camera.capturesPhotos
+                            onActivated:        (index) => { _camera.photoCaptureMode = index }
+                        }
+
+                        QGCSlider {
+                            Layout.fillWidth:   true
+                            to:                 60
+                            from:               1
+                            stepSize:           1
+                            value:              _camera.photoLapse
+                            displayValue:       true
+                            live:               true
+                            visible:            _camera.capturesPhotos && _camera.photoCaptureMode === MavlinkCameraControl.PHOTO_CAPTURE_TIMELAPSE
+                            onValueChanged:     _camera.photoLapse = value
+                        }
+
+                        QGCSwitch {
+                            checked:    _videoSettings.gridLines.rawValue
+                            visible:    _camera.hasVideoStream
+                            onClicked:  _videoSettings.gridLines.rawValue = checked ? 1 : 0
+                        }
+
+                        FactComboBox {
+                            Layout.fillWidth:   true
+                            sizeToContents:     true
+                            fact:               _videoSettings.videoFit
+                            indexModel:         false
+                            visible:            _camera.hasVideoStream
+                        }
+
+                        QGCButton {
+                            Layout.fillWidth:   true
+                            text:               qsTr("Reset")
+                            onClicked:          resetPrompt.open()
+                            MessageDialog {
+                                id:                 resetPrompt
+                                title:              qsTr("Reset Camera to Factory Settings")
+                                text:               qsTr("Confirm resetting all settings?")
+                                buttons:            MessageDialog.Yes | MessageDialog.No
+
+                                onButtonClicked: function (button, role) {
+                                    switch (button) {
+                                    case MessageDialog.Yes:
+                                        _camera.resetSettings()
+                                        resetPrompt.close()
+                                        break;
+                                    case MessageDialog.No:
+                                        resetPrompt.close()
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+
+                        QGCButton {
+                            Layout.fillWidth:   true
+                            text:               qsTr("Format")
+                            visible:            _cameraStorageSupported
+                            onClicked:          formatPrompt.open()
+                            MessageDialog {
+                                id:                 formatPrompt
+                                title:              qsTr("Format Camera Storage")
+                                text:               qsTr("Confirm erasing all files?")
+                                buttons:            MessageDialog.Yes | MessageDialog.No
+
+                                onButtonClicked: function (button, role) {
+                                    switch (button) {
+                                    case MessageDialog.Yes:
+                                        _camera.formatCard()
+                                        formatPrompt.close()
+                                        break;
+                                    case MessageDialog.No:
+                                        formatPrompt.close()
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/custom/src/FlyViewCustomLayer.qml
+++ b/custom/src/FlyViewCustomLayer.qml
@@ -12,6 +12,7 @@ import QtQuick.Controls
 
 import QGroundControl
 import QGroundControl.Controls
+import QGroundControl.FlightDisplay
 
 Item {
     id: root
@@ -23,6 +24,9 @@ Item {
     readonly property real _margin: ScreenTools.defaultFontPixelWidth
     readonly property bool _hasVehicle: QGroundControl.multiVehicleManager.activeVehicle !== null
     readonly property bool _hasCorePlugin: QGroundControl.corePlugin !== null && QGroundControl.corePlugin !== undefined
+    readonly property var  _cameraManager: _hasCorePlugin ? QGroundControl.corePlugin.cameraManager : null
+    readonly property real _buttonInset: buttonFlow.visible ? buttonFlow.implicitHeight + (_margin * 2) : 0
+    readonly property real _secondaryInset: secondaryStreamsColumn.visible ? (_buttonInset + secondaryStreamsColumn.implicitHeight + _margin) : 0
 
     function _triggerServo(channel, pulseWidth) {
         if (!_hasVehicle || !_hasCorePlugin) {
@@ -43,9 +47,29 @@ Item {
         topEdgeLeftInset: parentToolInsets.topEdgeLeftInset
         topEdgeCenterInset: parentToolInsets.topEdgeCenterInset
         topEdgeRightInset: parentToolInsets.topEdgeRightInset
-        bottomEdgeLeftInset: Math.max(parentToolInsets.bottomEdgeLeftInset, buttonFlow.visible ? buttonFlow.implicitHeight + (_margin * 2) : 0)
+        bottomEdgeLeftInset: Math.max(parentToolInsets.bottomEdgeLeftInset, _buttonInset, _secondaryInset)
         bottomEdgeCenterInset: parentToolInsets.bottomEdgeCenterInset
         bottomEdgeRightInset: parentToolInsets.bottomEdgeRightInset
+    }
+
+    Column {
+        id: secondaryStreamsColumn
+        anchors.left: parent.left
+        anchors.bottom: buttonFlow.top
+        anchors.leftMargin: _margin
+        anchors.bottomMargin: _margin
+        spacing: _margin / 2
+        visible: _cameraManager && _cameraManager.secondaryStreamsVisible && _cameraManager.secondaryCameras.length > 0
+
+        Repeater {
+            model: secondaryStreamsColumn.visible ? _cameraManager.secondaryCameras : []
+
+            CameraStreamView {
+                streamIndex: modelData.index
+                streamName: modelData.name
+                cameraManager: _cameraManager
+            }
+        }
     }
 
     Flow {

--- a/custom/src/SettingsPagesModel.qml
+++ b/custom/src/SettingsPagesModel.qml
@@ -70,6 +70,13 @@ ListModel {
     }
 
     ListElement {
+        name: qsTr("Camera manager")
+        url: "qrc:/Custom/qml/QGroundControl/AppSettings/CameraManagerSettings.qml"
+        iconUrl: "qrc:/Custom/res/camera_toggle_on.svg"
+        pageVisible: function() { return true }
+    }
+
+    ListElement {
         name: qsTr("Maps")
         url: "qrc:/qml/QGroundControl/AppSettings/MapSettings.qml"
         iconUrl: "qrc:/InstrumentValueIcons/globe.svg"


### PR DESCRIPTION
## Summary
- add the camera manager plugin sources to the custom override list so moc output is linked
- include the VideoReceiver header and clamp the saved primary index using ints so the custom camera manager builds on MSVC
- replace the std::clamp call with qBound and drop the unused JSON reserve to satisfy MSVC builds
- store camera entries in a std::vector and update index handling so MSVC no longer needs to copy unique_ptr receivers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9cd45cbbc832f91926b2c476a37d2