### PR TITLE
Retry VideoManager initialization after root window creation

### DIFF
--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -15,6 +15,7 @@
 #include <QtCore/QSet>
 #include <QtCore/QTimer>
 #include <QtCore/QTranslator>
+#include <QtCore/QMetaObject>
 #include <QtWidgets/QApplication>
 
 namespace QGCCommandLineParser {
@@ -165,6 +166,7 @@ private:
     bool _showErrorsInToolbar = false;
     QElapsedTimer _msecsElapsedTime;
     bool _videoManagerInitialized = false;
+    QMetaObject::Connection _videoInitConnection;
 
     QList<QPair<QString /* title */, QString /* message */>> _delayedAppMessages;
 


### PR DESCRIPTION
## Summary
- call `VideoManager::init` immediately and defer a retry only when the root window is missing
- keep a dedicated connection on `QGCApplication` to retry initialization once `objectCreated` fires and reset it afterward
- drop the unused `<memory>` include introduced by the previous attempt

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cad1d40ffc832f85dfaff422a3817b