### PR TITLE
Add custom version override for Lumiere build

### DIFF
--- a/custom/CMakeLists.txt
+++ b/custom/CMakeLists.txt
@@ -8,6 +8,7 @@ set(QGC_RESOURCES ${QGC_RESOURCES} ${CUSTOM_RESOURCES} CACHE STRING "Paths to .q
 set(CUSTOM_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/CustomPlugin.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/src/CustomPlugin.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/QGroundControlQmlGlobalCustom.cc
     CACHE INTERNAL "" FORCE
 )
 

--- a/custom/cmake/CustomOverrides.cmake
+++ b/custom/cmake/CustomOverrides.cmake
@@ -2,6 +2,7 @@
 list(APPEND CUSTOM_SOURCES
     ${CMAKE_SOURCE_DIR}/custom/src/CustomPlugin.cc
     ${CMAKE_SOURCE_DIR}/custom/src/CustomPlugin.h
+    ${CMAKE_SOURCE_DIR}/custom/src/QGroundControlQmlGlobalCustom.cc
 )
 
 # QML файл плагіна

--- a/custom/src/QGroundControlQmlGlobalCustom.cc
+++ b/custom/src/QGroundControlQmlGlobalCustom.cc
@@ -1,0 +1,25 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "QGroundControlQmlGlobal.h"
+
+#include <QtCore/QSysInfo>
+
+QString QGroundControlQmlGlobal::qgcVersion()
+{
+    QString versionStr = QStringLiteral("Lumiere QGC v0.1");
+
+    if (QSysInfo::buildAbi().contains("32")) {
+        versionStr += QStringLiteral(" %1").arg(tr("32 bit"));
+    } else if (QSysInfo::buildAbi().contains("64")) {
+        versionStr += QStringLiteral(" %1").arg(tr("64 bit"));
+    }
+
+    return versionStr;
+}

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -40,6 +40,7 @@
 
 #include <QtCore/QSettings>
 #include <QtCore/QLineF>
+#include <QtCore/QCoreApplication>
 
 QGC_LOGGING_CATEGORY(GuidedActionsControllerLog, "GuidedActionsControllerLog")
 
@@ -252,6 +253,7 @@ void QGroundControlQmlGlobal::setFlightMapZoom(double zoom)
     }
 }
 
+#ifndef QGC_CUSTOM_BUILD
 QString QGroundControlQmlGlobal::qgcVersion(void)
 {
     QString versionStr = QCoreApplication::applicationVersion();
@@ -265,6 +267,7 @@ QString QGroundControlQmlGlobal::qgcVersion(void)
     }
     return versionStr;
 }
+#endif
 
 QString QGroundControlQmlGlobal::altitudeModeExtraUnits(AltMode altMode)
 {


### PR DESCRIPTION
## Summary
- restore the default QGroundControlQmlGlobal::qgcVersion implementation for standard builds and guard it from custom builds
- add a custom-only translation unit that reports the Lumiere-branded version string with architecture suffix
- register the new override source in the custom build CMake configuration

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68caeeb413e0832f931954173b71eaa5